### PR TITLE
Fix module name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,6 @@ Fixes # (issue)
 ### Quick checks:
 
 - [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
-- [ ] There is no other [pull request](https://conduitio/conduit-connector-log/pulls) for the same update/change.
+- [ ] There is no other [pull request](https://github.com/conduitio/conduit-connector-log/pulls) for the same update/change.
 - [ ] I have written unit tests.
 - [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -15,9 +15,8 @@
 package main
 
 import (
+	log "github.com/conduitio/conduit-connector-log"
 	sdk "github.com/conduitio/conduit-connector-sdk"
-
-	log "conduitio/conduit-connector-log"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module conduitio/conduit-connector-log
+module github.com/conduitio/conduit-connector-log
 
 go 1.19
 


### PR DESCRIPTION
### Description

This fixes the module name of the connector. We need to fix the template as well (https://github.com/ConduitIO/conduit-connector-template/pull/2).