### PR TITLE
Add ability to control log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the log level of the connector in order for the records to show up in the logs.
 
 ### Configuration
 
-| name    | description                                    | required | default value |
-|---------|------------------------------------------------|----------|---------------|
-| `level` | Log level (ERROR, WARN, INFO, DEBUG or TRACE). | false    | INFO          |
-
+| name      | description                                                              | required | default value |
+|-----------|--------------------------------------------------------------------------|----------|---------------|
+| `level`   | Log level (ERROR, WARN, INFO, DEBUG or TRACE).                           | false    | INFO          |
+| `message` | Optional message that should be added to the log output of every record. | false    |               |

--- a/destination.go
+++ b/destination.go
@@ -24,14 +24,16 @@ import (
 )
 
 const (
-	ConfigLevel  = "level"
-	LevelDefault = zerolog.InfoLevel
+	ConfigLevel   = "level"
+	LevelDefault  = zerolog.InfoLevel
+	ConfigMessage = "message"
 )
 
 type Destination struct {
 	sdk.UnimplementedDestination
 
 	level zerolog.Level
+	msg   string
 }
 
 func NewDestination() sdk.Destination {
@@ -44,6 +46,10 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 			Default:     "INFO",
 			Required:    true,
 			Description: "The log level used to log records.",
+		},
+		ConfigMessage: {
+			Required:    false,
+			Description: "Optional message that should be added to the log output of every record.",
 		},
 	}
 }
@@ -61,6 +67,7 @@ func (d *Destination) Configure(ctx context.Context, cfg map[string]string) erro
 		}
 	}
 	d.level = level
+	d.msg, _ = cfg[ConfigMessage]
 	return nil
 }
 
@@ -73,7 +80,7 @@ func (d *Destination) Write(ctx context.Context, records []sdk.Record) (int, err
 	for _, r := range records {
 		logger.WithLevel(d.level).
 			RawJSON("record", r.Bytes()).
-			Send()
+			Msg(d.msg)
 	}
 	return len(records), nil
 }

--- a/destination.go
+++ b/destination.go
@@ -44,7 +44,7 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
 		ConfigLevel: {
 			Default:     "INFO",
-			Required:    true,
+			Required:    false,
 			Description: "The log level used to log records.",
 		},
 		ConfigMessage: {

--- a/destination.go
+++ b/destination.go
@@ -67,7 +67,7 @@ func (d *Destination) Configure(ctx context.Context, cfg map[string]string) erro
 		}
 	}
 	d.level = level
-	d.msg, _ = cfg[ConfigMessage]
+	d.msg = cfg[ConfigMessage]
 	return nil
 }
 

--- a/destination_test.go
+++ b/destination_test.go
@@ -71,7 +71,7 @@ func TestDestination_Configure_Write(t *testing.T) {
 
 	var dest Destination
 
-	err := dest.Configure(ctx, map[string]string{"level": "warn"})
+	err := dest.Configure(ctx, map[string]string{"level": "warn", "message": "foo!"})
 	is.NoErr(err)
 
 	have := []sdk.Record{{
@@ -95,8 +95,8 @@ func TestDestination_Configure_Write(t *testing.T) {
 	}}
 
 	want := []string{
-		`{"level":"warn","record":{"position":"cjE=","operation":"create","metadata":{"foo1":"bar1","opencdc.version":"v1"},"key":"cmF3LWtleQ==","payload":{"before":null,"after":"cmF3LXBheWxvYWQ="}}}`,
-		`{"level":"warn","record":{"position":"cjI=","operation":"update","metadata":{"foo2":"bar2","opencdc.version":"v1"},"key":{"r2-key":1},"payload":{"before":{"r2-payload":true},"after":{"r2-payload":false}}}}`,
+		`{"level":"warn","record":{"position":"cjE=","operation":"create","metadata":{"foo1":"bar1","opencdc.version":"v1"},"key":"cmF3LWtleQ==","payload":{"before":null,"after":"cmF3LXBheWxvYWQ="}},"message":"foo!"}`,
+		`{"level":"warn","record":{"position":"cjI=","operation":"update","metadata":{"foo2":"bar2","opencdc.version":"v1"},"key":{"r2-key":1},"payload":{"before":{"r2-payload":true},"after":{"r2-payload":false}}},"message":"foo!"}`,
 	}
 
 	l, err := dest.Write(ctx, have)


### PR DESCRIPTION
### Description

This will be useful in DLQs since we'll be able to add a log message like "record delivery failed" or similar.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/conduitio/conduit-connector-log/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
