### PR TITLE
document logging issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ that contains raw byte data.
 
 Keep in mind that Conduit's log level needs to be configured lower or equal to
 the log level of the connector in order for the records to show up in the logs.
+
+### Known issues
+
+- **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages bigger than 64KB will not be logged when using `log.level` as `info`.
+  This is a known issue cause by the default buffer value of `go-plugin`. More information, on [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
 <!-- /readmegen:description -->
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ the log level of the connector in order for the records to show up in the logs.
 
 ### Known issues
 
-- **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages bigger than 64KB will not be logged when using `log.level` as `info`.
-  This is a known issue cause by the default buffer value of `go-plugin`. More information, on [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
+- **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
+  This is a known issue caused by the default buffer value of `go-plugin`. More information can be found in [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
 <!-- /readmegen:description -->
 
 ## Configuration

--- a/connector.yaml
+++ b/connector.yaml
@@ -21,8 +21,8 @@ specification:
 
     ### Known issues
 
-    - **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages bigger than 64KB will not be logged when using `log.level` as `info`.
-      This is a known issue cause by the default buffer value of `go-plugin`. More information, on [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
+    - **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
+      This is a known issue caused by the default buffer value of `go-plugin`. More information can be found in [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
   version: v0.7.2
   author: Meroxa, Inc.
   destination:

--- a/connector.yaml
+++ b/connector.yaml
@@ -18,6 +18,11 @@ specification:
 
     Keep in mind that Conduit's log level needs to be configured lower or equal to
     the log level of the connector in order for the records to show up in the logs.
+
+    ### Known issues
+
+    - **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages bigger than 64KB will not be logged when using `log.level` as `info`.
+      This is a known issue cause by the default buffer value of `go-plugin`. More information, on [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
   version: v0.7.2
   author: Meroxa, Inc.
   destination:


### PR DESCRIPTION
### Description

Fixes #81.

Readme update can be seen [here](https://github.com/ConduitIO/conduit-connector-log/blob/document-message-limit/README.md).

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio/conduit-connector-log/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
