### PR TITLE
chore: re-release v0.7.5 (signed-artifact fixes)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,5 +106,5 @@ jobs:
           # fragment. Omit on subsequent version bumps (routing.Decide ignores
           # it once the name exists).
           first-registration-identity-ref-pattern: 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+'
-          provenance-bundle-url: ${{ needs.provenance.outputs.provenance-bundle-url }}
+          provenance-bundle-url: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ needs.provenance.outputs.provenance-name }}
           index-repo-token: ${{ secrets.REGISTRY_INDEX_PR_TOKEN }}

--- a/connector.yaml
+++ b/connector.yaml
@@ -23,7 +23,7 @@ specification:
 
     - **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
       This is a known issue caused by the default buffer value of `go-plugin`. More information can be found in [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
-  version: v0.7.4
+  version: v0.7.5
   author: Meroxa, Inc.
   destination:
     parameters:


### PR DESCRIPTION
Re-release with the full fix set (new bundle format, tar.gz packaging, provenance URL) validated end-to-end on conduit-connector-file. Tier-3.